### PR TITLE
Upgrade to yew 0.11 and yew_router 0.8

### DIFF
--- a/crates/yew-app/Cargo.toml
+++ b/crates/yew-app/Cargo.toml
@@ -17,10 +17,10 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 web_logger = "0.2"
-yew = "0.10.0"
-yew-router = "0.7.0"
-wasm-bindgen = "0.2.56"
+yew = "0.11.0"
+yew-router = "0.8.1"
+wasm-bindgen = "0.2.58"
 wee_alloc = "0.4.5"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.6"
+wasm-bindgen-test = "0.3.8"

--- a/crates/yew-app/src/app.rs
+++ b/crates/yew-app/src/app.rs
@@ -1,5 +1,6 @@
 use yew::prelude::*;
 use yew_router::{prelude::*, route::Route};
+use yew_router::switch::Permissive;
 
 use crate::components::nav::Nav;
 use crate::routes::{about::About, home::Home, AppRoute};
@@ -19,7 +20,7 @@ impl Component for App {
         true
     }
 
-    fn view(&self) -> Html<Self> {
+    fn view(&self) -> Html {
         html! {
             <>
                 <Nav />
@@ -28,12 +29,12 @@ impl Component for App {
                         match switch {
                             AppRoute::Home => html!{ <Home /> },
                             AppRoute::About => html!{ <About /> },
-                            AppRoute::PageNotFound(None) => html!{"Page not found"},
-                            AppRoute::PageNotFound(Some(missed_route)) => html!{format!("Page '{}' not found", missed_route)}
+                            AppRoute::PageNotFound(Permissive(None)) => html!{"Page not found"},
+                            AppRoute::PageNotFound(Permissive(Some(missed_route))) => html!{format!("Page '{}' not found", missed_route)}
                         }
                     } )
                     redirect = Router::redirect(|route: Route<()>| {
-                        AppRoute::PageNotFound(Some(route.route))
+                        AppRoute::PageNotFound(Permissive(Some(route.route)))
                     })
                 />
             </>

--- a/crates/yew-app/src/components/nav.rs
+++ b/crates/yew-app/src/components/nav.rs
@@ -1,6 +1,8 @@
 use yew::prelude::*;
 use yew_router::prelude::*;
 
+use crate::routes::AppRoute;
+
 /// Nav component
 pub struct Nav;
 
@@ -16,12 +18,12 @@ impl Component for Nav {
         true
     }
 
-    fn view(&self) -> Html<Self> {
+    fn view(&self) -> Html {
         html! {
             <nav>
                 <ul>
-                    <li><RouterLink text="Home" link="/" classes="app-link"/></li>
-                    <li><RouterLink text="About" link="/about" classes="app-link"/></li>
+                    <li><RouterAnchor<AppRoute> route=AppRoute::Home classes="app-link" >{ "Home" }</RouterAnchor<AppRoute>></li>
+                    <li><RouterAnchor<AppRoute> route=AppRoute::About classes="app-link">{ "About" }</RouterAnchor<AppRoute>></li>
                 </ul>
             </nav>
         }

--- a/crates/yew-app/src/routes/about.rs
+++ b/crates/yew-app/src/routes/about.rs
@@ -15,7 +15,7 @@ impl Component for About {
         true
     }
 
-    fn view(&self) -> Html<Self> {
+    fn view(&self) -> Html {
         html! {
             <div class="app">
                 <header class="app-header">

--- a/crates/yew-app/src/routes/home.rs
+++ b/crates/yew-app/src/routes/home.rs
@@ -15,7 +15,7 @@ impl Component for Home {
         true
     }
 
-    fn view(&self) -> Html<Self> {
+    fn view(&self) -> Html {
         html! {
             <div class="app">
                 <header class="app-header">

--- a/crates/yew-app/src/routes/mod.rs
+++ b/crates/yew-app/src/routes/mod.rs
@@ -1,4 +1,5 @@
 use yew_router::prelude::*;
+use yew_router::switch::Permissive;
 
 pub mod about;
 pub mod home;
@@ -9,7 +10,7 @@ pub enum AppRoute {
     #[to = "/about"]
     About,
     #[to = "/page-not-found"]
-    PageNotFound(Option<String>),
+    PageNotFound(Permissive<String>),
     #[to = "/"]
     Home,
 }


### PR DESCRIPTION
Upgrade yew and yew_router, but still having build errors:
```
/Users/jetli/repos/3rdparty/create-yew-app/crates/yew-app/Cargo.toml: Command failed: wasm-pack build --dev
[INFO]: Checking for the Wasm target...
[INFO]: Compiling to Wasm...
   Compiling stdweb v0.4.20
error[E0463]: can't find crate for `stdweb_internal_macros`
   --> /Users/jetli/.cargo/registry/src/github.com-1ecc6299db9ec823/stdweb-0.4.20/src/lib.rs:142:1
    |
142 | extern crate stdweb_internal_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
    |
    = note: extern location for stdweb_internal_macros is of an unknown type: /Users/jetli/repos/3rdparty/create-yew-app/target/debug/deps/libstdweb_internal_macros-514a12fe27aecec8.dylib
    = help: file name should be lib*.rlib or *..wasm

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: could not compile `stdweb`.

To learn more, run the command again with --verbose.
Error: Compiling your crate to WebAssembly failed
Caused by: failed to execute `cargo build`: exited with exit code: 101
```