### PR TITLE
Updated dependencies and replaced allocator

### DIFF
--- a/crates/yew-app/Cargo.toml
+++ b/crates/yew-app/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["You <you@example.com>"]
 categories = ["wasm"]
 description = "My awesome Yew app."
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0/MIT"
 name = "yew-app"
 readme = "./README.md"
@@ -15,24 +15,19 @@ version = "0.1.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-log = "0.4"
-serde = "1"
-reqwest = { version = "0.11", features = ["json"] }
+log = "0.4.17"
+serde = "1.0.145"
+reqwest = { version = "0.11.12", features = ["json"] }
 yew = "0.19.3"
 yew-router = "0.16.0"
 yew-hooks = "0.1.56"
-wasm-bindgen = "=0.2.80"
+wasm-bindgen = "0.2.83"
 wasm-logger = "0.2.0"
-wee_alloc = "0.4.5"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.14"
 gloo-utils = "0.1.0"
 
 [dev-dependencies.web-sys]
-version = "0.3"
-features = [
-  "Document",
-  "Element",
-  "HtmlCollection",
-]
+version = "0.3.60"
+features = ["Document", "Element", "HtmlCollection"]

--- a/crates/yew-app/src/lib.rs
+++ b/crates/yew-app/src/lib.rs
@@ -6,9 +6,9 @@ use wasm_bindgen::prelude::*;
 
 use app::App;
 
-// Use `wee_alloc` as the global allocator.
+// Use `std::alloc` as the global allocator.
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOC: std::alloc::System = std::alloc::System;
 
 // This is the entry point for the web app
 #[wasm_bindgen]


### PR DESCRIPTION
**What has been made?**
- A simple dependencies update.
- Removed the wee_alloc crate, it's unmaintained and the creators recommend to use the alloc in the std module.

The wasm-bindgen has been updated too, in the last comment of #21 i have commented that the version
`wasm-bindgen = "0.2.83"`
Is ok to use again :D